### PR TITLE
Support oracle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ ENV \
   JS_DB_USER=jasper \
   JS_DB_PASSWORD=my_password \
   JASPERSERVER_HOME=/jasperserver \
-  JASPERSERVER_BUILD=/jasperserver/buildomatic
+  JASPERSERVER_BUILD=/jasperserver/buildomatic \
+  JS_ENABLE_SAVE_TO_HOST_FS=false
   
 COPY entrypoint.sh /  
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ docker run -d -v /var/lib/mysql --name jasperserver-db-storage busybox:latest
 docker run \
     --name jasperserver-db \
     -v /etc/localtime:/etc/localtime:ro \
+    -v /etc/timezone:/etc/timezone:ro \
     --volumes-from jasperserver-db-storage \
     --env="MARIADB_USER=jasper" \
     --env="MARIADB_PASS=my_password" \
@@ -20,6 +21,7 @@ docker run \
     --name jasperserver \
     -p 8080:8080 \
     -v /etc/localtime:/etc/localtime:ro \
+    -v /etc/timezone:/etc/timezone:ro \
     --link jasperserver-db:jasper.db \
     --env="JS_DB_HOST=jasper.db" \
     --env="JS_DB_USER=jasper" \

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ You can use environment variables to configure JasperServer container:
 | JS_Xmx | 512m | |
 | JS_MaxPermSize | 256m | |
 | JS_CATALINA_OPTS | -XX:+UseBiasedLocking -XX:BiasedLockingStartupDelay=0 -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:+DisableExplicitGC -XX:+CMSIncrementalMode -XX:+CMSIncrementalPacing -XX:+CMSParallelRemarkEnabled -XX:+UseCompressedOops -XX:+UseCMSInitiatingOccupancyOnly | |
+| JS_ENABLE_SAVE_TO_HOST_FS | false | This enable the scheduled reports to be saved in the host |
+
 
 # Integrations
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ jasperserver-db:
   image: zabbix/zabbix-db-mariadb
   volumes:
     - /etc/localtime:/etc/localtime:ro
+    - /etc/timezone:/etc/timezone:ro
   volumes_from:
     - jasperserver-db-storage
   environment:
@@ -19,6 +20,7 @@ jasperserver:
     - "8080:8080"
   volumes:
     - /etc/localtime:/etc/localtime:ro
+    - /etc/timezone:/etc/timezone:ro
   links:
     - jasperserver-db:jasper.db
   environment:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ setup_jasperserver() {
     JS_DB_USER=${JS_DB_USER:-jasper}
     JS_DB_PASSWORD=${JS_DB_PASSWORD:-my_password}
     JS_DB_PORT=${JS_DB_PORT:-3306}
-
+    JS_ENABLE_SAVE_TO_HOST_FS=${JS_ENABLE_SAVE_TO_HOST_FS:-false}
     pushd ${JASPERSERVER_BUILD}
     cp sample_conf/${JS_DB_TYPE}_master.properties default_master.properties
     sed -i -e "s|^appServerDir.*$|appServerDir = $CATALINA_HOME|g; s|^dbHost.*$|dbHost=$JS_DB_HOST|g; s|^dbUsername.*$|dbUsername=$JS_DB_USER|g; s|^dbPassword.*$|dbPassword=$JS_DB_PASSWORD|g" default_master.properties
@@ -18,6 +18,11 @@ setup_jasperserver() {
         ./js-ant $i
     done
 
+    if [ "${JS_ENABLE_SAVE_TO_HOST_FS}" = "true" ]; then
+    	# Change the value of enableSaveToHostFS to true
+    	sed -i "s/\(<property name=\"enableSaveToHostFS\" value=\"\).*\(\"\/>\)/\1${JS_ENABLE_SAVE_TO_HOST_FS}\2/" /usr/local/tomcat/webapps/jasperserver/WEB-INF/applicationContext.xml
+    fi
+    
     popd
 }
 


### PR DESCRIPTION
Oracle jdbc driver needs a timezone to work. This change brings the host timezone to the container
