### PR TITLE
fix mariadb dependancy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ jasperserver-db-storage:
     - /var/lib/mysql
 
 jasperserver-db:
-  image: zabbix/zabbix-db-mariadb
+  image: monitoringartist/zabbix-db-mariadb
   volumes:
     - /etc/localtime:/etc/localtime:ro
   volumes_from:


### PR DESCRIPTION
I've just tried to launch your latest docker-compose file but it complains "Error: image zabbix/zabbix-db-mariadb:latest not found". With monitoringartist/zabbix-db-mariadb:latest instead it seams to be working.